### PR TITLE
Fix LICENSE headers & indentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,208 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=============================================================================
+
 MIT License
 
 Copyright (c) 2020 Niko Köbler

--- a/README.md
+++ b/README.md
@@ -1,17 +1,8 @@
 # Keycloak 2FA SMS Authenticator
 
-Keycloak Authentication Provider implementation to get a 2nd-factor authentication with a OTP/code/token send via SMS (through AWS SNS).
+Keycloak Authentication Provider implementation to get a 2nd-factor authentication with a OTP/code/token send via SMS with a configurable HTTPS API. It should be possible to interact with most SMS providers. Issues and pull requests to support more SMS providers are welcome.
 
-_Demo purposes only!_
+This is a fork of a great demo implementation by [@dasniko](https://github.com/dasniko/keycloak-2fa-sms-authenticator), and also takes huge chunks of code from the original authenticator provider [documentation](https://www.keycloak.org/docs/latest/server_development/index.html#_auth_spi) and [example](https://github.com/keycloak/keycloak/tree/main/examples/providers/authenticator) from Keycloak itself.
 
-Unfortunately, I don't have a real readme yet.
-Blame on me!
-
-But, for now, you can at least read my **blog post** about this autenticator here:  
-https://www.n-k.de/2020/12/keycloak-2fa-sms-authentication.html
-
-Or, just watch my **video** about this 2FA SMS SPI:
-
-[![](http://img.youtube.com/vi/GQi19817fFk/maxresdefault.jpg)](http://www.youtube.com/watch?v=GQi19817fFk "")
-
-[![](http://img.youtube.com/vi/FHJ5WOx1es0/maxresdefault.jpg)](http://www.youtube.com/watch?v=FHJ5WOx1es0 "")
+# License
+The code of this project is Apache 2.0 licensed. Parts of the original code are MIT licensed.

--- a/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @author Niko Köbler, https://www.n-k.de, @dasniko
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
 package netzbegruenung.keycloak.authenticator;
 
 import netzbegruenung.keycloak.authenticator.gateway.SmsServiceFactory;
@@ -29,9 +51,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * @author Netzbegruenung e.V.
- */
 public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsMobileNumberProvider> {
 
 	private static final String TPL_CODE = "login-sms.ftl";
@@ -130,8 +149,8 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsM
 	}
 
 	public List<RequiredActionFactory> getRequiredActions(KeycloakSession session) {
-        return Collections.singletonList((SmsAuthenticatorActionFactory)session.getKeycloakSessionFactory().getProviderFactory(RequiredActionProvider.class, SmsAuthenticatorSetMobileNumberAction.PROVIDER_ID));
-    }
+		return Collections.singletonList((SmsAuthenticatorActionFactory)session.getKeycloakSessionFactory().getProviderFactory(RequiredActionProvider.class, SmsAuthenticatorSetMobileNumberAction.PROVIDER_ID));
+	}
 
 	@Override
 	public void close() {

--- a/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorActionFactory.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorActionFactory.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @author Netzbegruenung e.V.
  */
+
 
 package netzbegruenung.keycloak.authenticator;
 
@@ -23,10 +27,6 @@ import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
-/**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
- * @version $Revision: 1 $
- */
 public class SmsAuthenticatorActionFactory implements RequiredActionFactory {
 
     private static final SmsAuthenticatorSetMobileNumberAction SINGLETON = new SmsAuthenticatorSetMobileNumberAction();

--- a/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorActionFactory.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorActionFactory.java
@@ -16,6 +16,7 @@
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @author Netzbegruenung e.V.
+ * @author verdigado eG
  */
 
 

--- a/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorData.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorData.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * @author <a href="mailto:alistair.doswald@elca.ch">Alistair Doswald</a>
+ * @version $Revision: 1 $
+ */
+
 package netzbegruenung.keycloak.authenticator;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFactory.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFactory.java
@@ -1,6 +1,27 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ * @author Niko Köbler, https://www.n-k.de, @dasniko
+ */
+
 package netzbegruenung.keycloak.authenticator;
 
-import netzbegruenung.keycloak.authenticator.SmsMobileNumberProvider;
 import org.keycloak.Config;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.AuthenticatorFactory;
@@ -8,14 +29,9 @@ import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderConfigProperty;
-import org.keycloak.authentication.RequiredActionContext;
 
-import org.jboss.logging.Logger;
 import java.util.List;
 
-/**
- * @author Netzbegruenung e.V.
- */
 public class SmsAuthenticatorFactory implements AuthenticatorFactory {
 
 	public static final String PROVIDER_ID = "mobile-number-authenticator";

--- a/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorModel.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorModel.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author <a href="mailto:alistair.doswald@elca.ch">Alistair Doswald</a>
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
 package netzbegruenung.keycloak.authenticator;
 
 import netzbegruenung.keycloak.authenticator.SmsAuthenticatorModel;

--- a/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorSetMobileNumberAction.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorSetMobileNumberAction.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
 package netzbegruenung.keycloak.authenticator;
 
 import org.keycloak.authentication.CredentialRegistrator;

--- a/src/main/java/netzbegruenung/keycloak/authenticator/SmsMobileNumberProvider.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/SmsMobileNumberProvider.java
@@ -13,10 +13,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
  */
-package netzbegruenung.keycloak.authenticator;
 
-import netzbegruenung.keycloak.authenticator.SmsAuthenticatorModel;
+package netzbegruenung.keycloak.authenticator;
 
 import org.keycloak.common.util.Time;
 import org.keycloak.credential.CredentialInput;
@@ -33,10 +36,6 @@ import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import java.util.*;
 
-/**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
- * @version $Revision: 1 $
- */
 public class SmsMobileNumberProvider implements CredentialProvider<SmsAuthenticatorModel>, CredentialInputValidator, CredentialInputUpdater {
 
     protected KeycloakSession session;

--- a/src/main/java/netzbegruenung/keycloak/authenticator/SmsMobileNumberProviderFactory.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/SmsMobileNumberProviderFactory.java
@@ -13,17 +13,19 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * @author Bill Burke
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
  */
+
 package netzbegruenung.keycloak.authenticator;
 
 import org.keycloak.credential.CredentialProvider;
 import org.keycloak.credential.CredentialProviderFactory;
 import org.keycloak.models.KeycloakSession;
 
-/**
- * @author Bill Burke
- * @version $Revision: 1 $
- */
+
 public class SmsMobileNumberProviderFactory implements CredentialProviderFactory<SmsMobileNumberProvider> {
 
     public static final String PROVIDER_ID =  "mobile-number";

--- a/src/main/java/netzbegruenung/keycloak/authenticator/gateway/ApiSmsService.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/gateway/ApiSmsService.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Niko Köbler, https://www.n-k.de, @dasniko
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
 package netzbegruenung.keycloak.authenticator.gateway;
 
 import java.util.Map;
@@ -11,9 +32,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import org.jboss.logging.Logger;
 
-/**
- * @author Netzbegrünung e.V.
- */
 public class ApiSmsService implements SmsService{
 
 	private final String apiurl;
@@ -56,18 +74,18 @@ public class ApiSmsService implements SmsService{
 	}
 
 	public void send_json(String phoneNumber, String message) {
-        String sendJson = "{"
-            .concat(apitokenattribute != "" ? String.format("\"%s\":\"%s\",", apitokenattribute, apitoken): "")
-            .concat(String.format("\"%s\":\"%s\",", messageattribute, message))
-            .concat(String.format("\"%s\":\"%s\",", receiverattribute, phoneNumber))
-            .concat(String.format("\"%s\":\"%s\"", senderattribute, from))
-            .concat("}");
+		String sendJson = "{"
+			.concat(apitokenattribute != "" ? String.format("\"%s\":\"%s\",", apitokenattribute, apitoken): "")
+			.concat(String.format("\"%s\":\"%s\",", messageattribute, message))
+			.concat(String.format("\"%s\":\"%s\",", receiverattribute, phoneNumber))
+			.concat(String.format("\"%s\":\"%s\"", senderattribute, from))
+			.concat("}");
 
-        var request = HttpRequest.newBuilder()
-            .uri(URI.create(apiurl))
-            .header("Content-Type", "application/json")
-            .POST(HttpRequest.BodyPublishers.ofString(sendJson))
-            .build();
+		var request = HttpRequest.newBuilder()
+			.uri(URI.create(apiurl))
+			.header("Content-Type", "application/json")
+			.POST(HttpRequest.BodyPublishers.ofString(sendJson))
+			.build();
 
         var client = HttpClient.newHttpClient();
 
@@ -92,12 +110,12 @@ public class ApiSmsService implements SmsService{
 		formData.put(receiverattribute, phoneNumber);
 		formData.put(senderattribute, from);
 
-	    var client = HttpClient.newHttpClient();
-	    var form_data = getFormDataAsString(formData);
-	    var request = HttpRequest.newBuilder(URI.create(apiurl))
-	            .POST(HttpRequest.BodyPublishers.ofString(form_data))
-	            .build();
-	    try {
+		var client = HttpClient.newHttpClient();
+		var form_data = getFormDataAsString(formData);
+		var request = HttpRequest.newBuilder(URI.create(apiurl))
+			.POST(HttpRequest.BodyPublishers.ofString(form_data))
+			.build();
+		try {
 			client.send(request, HttpResponse.BodyHandlers.ofString());
 		} catch (IOException e) {
 			LOG.warn(String.format("Failed to send message to %s with params %s", apiurl, form_data));
@@ -109,15 +127,15 @@ public class ApiSmsService implements SmsService{
 	}
 
 	private static String getFormDataAsString(Map<String, String> formData) {
-	    StringBuilder formBodyBuilder = new StringBuilder();
-	    for (Map.Entry<String, String> singleEntry : formData.entrySet()) {
-	        if (formBodyBuilder.length() > 0) {
-	            formBodyBuilder.append("&");
-	        }
-	        formBodyBuilder.append(URLEncoder.encode(singleEntry.getKey(), StandardCharsets.UTF_8));
-	        formBodyBuilder.append("=");
-	        formBodyBuilder.append(URLEncoder.encode(singleEntry.getValue(), StandardCharsets.UTF_8));
-	    }
-	    return formBodyBuilder.toString();
+		StringBuilder formBodyBuilder = new StringBuilder();
+		for (Map.Entry<String, String> singleEntry : formData.entrySet()) {
+			if (formBodyBuilder.length() > 0) {
+				formBodyBuilder.append("&");
+			}
+			formBodyBuilder.append(URLEncoder.encode(singleEntry.getKey(), StandardCharsets.UTF_8));
+			formBodyBuilder.append("=");
+			formBodyBuilder.append(URLEncoder.encode(singleEntry.getValue(), StandardCharsets.UTF_8));
+		}
+		return formBodyBuilder.toString();
 	}
 }

--- a/src/main/java/netzbegruenung/keycloak/authenticator/gateway/SmsService.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/gateway/SmsService.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Niko Köbler, https://www.n-k.de, @dasniko
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
 package netzbegruenung.keycloak.authenticator.gateway;
 
-import java.util.Map;
-
-/**
- * @author Netzbegruenung e.V.
- */
 public interface SmsService {
 
 	void send(String phoneNumber, String message);

--- a/src/main/java/netzbegruenung/keycloak/authenticator/gateway/SmsServiceFactory.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/gateway/SmsServiceFactory.java
@@ -1,13 +1,30 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Niko Köbler, https://www.n-k.de, @dasniko
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
 package netzbegruenung.keycloak.authenticator.gateway;
 
-import netzbegruenung.keycloak.authenticator.gateway.ApiSmsService;
 import org.jboss.logging.Logger;
 
 import java.util.Map;
 
-/**
- * @author Netzbegruenung e.V.
- */
 public class SmsServiceFactory {
 
 	private static final Logger LOG = Logger.getLogger(SmsServiceFactory.class);


### PR DESCRIPTION
* Add Apache 2.0 boiler plates, fixes #10
* Add contributing authors.
* Fix indentation in files where tabs and spaces were mixed.
* Remove unused imports.