### PR TITLE
Fix active required actions check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>netzbegruenung</groupId>
 	<artifactId>keycloak-2fa-sms-authenticator</artifactId>
-	<version>0.2.1</version>
+	<version>0.2.2</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
@@ -40,7 +40,7 @@ import java.util.Locale;
 import javax.ws.rs.core.Response;
 
 public class PhoneValidationRequiredAction implements RequiredActionProvider, CredentialRegistrator {
-	private static final Logger LOG = Logger.getLogger(PhoneValidationRequiredAction.class);
+	private static final Logger logger = Logger.getLogger(PhoneValidationRequiredAction.class);
 	public static final String PROVIDER_ID = "phone_validation_config";
 
 	@Override
@@ -58,7 +58,7 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 			AuthenticatorConfigModel config = context.getRealm().getAuthenticatorConfigByAlias("sms-2fa");
 
 			String mobileNumber = authSession.getAuthNote("mobile_number");
-			LOG.info(String.format("%s", mobileNumber));
+			logger.infof("Validating phone number: %s of user: %s", mobileNumber, user.getUsername());
 
 			int length = Integer.parseInt(config.getConfig().get("length"));
 			int ttl = Integer.parseInt(config.getConfig().get("ttl"));
@@ -95,7 +95,7 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 		String ttl = authSession.getAuthNote("ttl");
 
 		if (code == null || ttl == null || enteredCode == null) {
-			LOG.warn("Phone number is not set");
+			logger.warn("Phone number is not set");
 			handleInvalidSmsCode(context);
 			return;
 		}

--- a/src/main/java/netzbegruenung/keycloak/authenticator/gateway/ApiSmsService.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/gateway/ApiSmsService.java
@@ -50,7 +50,7 @@ public class ApiSmsService implements SmsService{
 	private final String receiverattribute;
 	private final String senderattribute;
 
-	private static final Logger LOG = Logger.getLogger(SmsServiceFactory.class);
+	private static final Logger logger = Logger.getLogger(SmsServiceFactory.class);
 
 	ApiSmsService(Map<String, String> config) {
 		apiurl = config.get("apiurl");
@@ -85,14 +85,14 @@ public class ApiSmsService implements SmsService{
 				request = request_builder.build();
 			}
 			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-			LOG.warn(String.format("API request: %s", response.toString()));
+			logger.infof("API request: %s", response.toString());
 			if (response.statusCode() == 200) {
-				LOG.warn(String.format("Sent SMS to %s; API response: %s", phoneNumber, response.body()));
+				logger.infof("Sent SMS to %s; API response: %s", phoneNumber, response.body());
 			} else {
-				LOG.warn(String.format("Failed to send message to %s with answer: %s. Validate your config.", phoneNumber, response.body()));
+				logger.errorf("Failed to send message to %s with answer: %s. Validate your config.", phoneNumber, response.body());
 			}
 		} catch (Exception e){
-			LOG.warn(String.format("Failed to send message to %s with request: %s. Validate your config.", phoneNumber, request.toString()));
+			logger.errorf("Failed to send message to %s with request: %s. Validate your config.", phoneNumber, request.toString());
 			e.printStackTrace();
 			return;
 		}

--- a/src/main/java/netzbegruenung/keycloak/authenticator/gateway/SmsServiceFactory.java
+++ b/src/main/java/netzbegruenung/keycloak/authenticator/gateway/SmsServiceFactory.java
@@ -27,12 +27,12 @@ import java.util.Map;
 
 public class SmsServiceFactory {
 
-	private static final Logger LOG = Logger.getLogger(SmsServiceFactory.class);
+	private static final Logger logger = Logger.getLogger(SmsServiceFactory.class);
 
 	public static SmsService get(Map<String, String> config) {
 		if (Boolean.parseBoolean(config.getOrDefault("simulation", "false"))) {
 			return (phoneNumber, message) ->
-				LOG.warn(String.format("***** SIMULATION MODE ***** Would send SMS to %s with text: %s", phoneNumber, message));
+				logger.infof("***** SIMULATION MODE ***** Would send SMS to %s with text: %s", phoneNumber, message);
 		} else {
 			return new ApiSmsService(config);
 		}


### PR DESCRIPTION
When 2FA is enforced, required actions set for TOTP or WebAuthn are taken into account, too.
I.e. when TOTP or Webauthn required actions are set, no SMS Authenticator required actions are triggered.

Fixes: #39