### PR TITLE
Optimize 2FA enforcement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>netzbegruenung</groupId>
 	<artifactId>keycloak-2fa-sms-authenticator</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Abort 2FA enforcement code as soon as possible:
1. Check credentials and if any 2FA method is found then abort
2. Check auth session for already set required actions
3. Check user model for required actions We may try to switch the order to optimize further.

Fixes: #55